### PR TITLE
Add /opt/gvclass to PATH

### DIFF
--- a/containers/apptainer/gvclass.def
+++ b/containers/apptainer/gvclass.def
@@ -6,7 +6,7 @@ From: ghcr.io/prefix-dev/pixi:latest
     . /opt/gvclass_staging
 
 %environment
-    export PATH=/opt/gvclass/.pixi/envs/default/bin:$PATH
+    export PATH=/opt/gvclass:/opt/gvclass/.pixi/envs/default/bin:$PATH
     export PYTHONPATH=/opt/gvclass:$PYTHONPATH
 
 %post

--- a/containers/docker/Dockerfile
+++ b/containers/docker/Dockerfile
@@ -29,7 +29,7 @@ RUN pixi clean cache -y || true && \
     find /opt/gvclass -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true
 
 # Set environment variables
-ENV PATH="/opt/gvclass/.pixi/envs/default/bin:${PATH}"
+ENV PATH="/opt/gvclass:/opt/gvclass/.pixi/envs/default/bin:${PATH}"
 ENV PYTHONPATH="/opt/gvclass:${PYTHONPATH}"
 
 # Create mount points for input/output with proper permissions


### PR DESCRIPTION
Adding `/opt/gvclass` to PATH allows to run `singularity exec gvclass.sif gvclass` directly which makes integration in workflows, such as Snakemake, more straightforward:

```snakemake
rule gvclass:
    input: "analysis/batch"
    output: directory("analysis/gvclass")
    threads: 16
    container: "library://nelligroup-jgi/gvclass/gvclass:1.5.1"
    shell: "gvclass {input} -o {output} -t {threads}"
    # Instead of shell: "/opt/gvclass/gvclass {input} ..."
    # OR adding --env PREPEND_PATH=/opt/gvclass
```

(As a side note: I have to add `singularity-args: "--fakeroot"` for snakemake as in the image pulled from library://nelligroup-jgi/gvclass/gvclass:1.5.1, files under /opt/gvclass belong to root and are under permission 700).